### PR TITLE
Tasseled Cap Transformations

### DIFF
--- a/docs/modules/Spectral.rst
+++ b/docs/modules/Spectral.rst
@@ -9,3 +9,4 @@ Extra.Spectral
    indices
    listIndices
    spectralIndices
+   tasseledCap

--- a/docs/modules/stubs/ee_extra.Spectral.core.tasseledCap.rst
+++ b/docs/modules/stubs/ee_extra.Spectral.core.tasseledCap.rst
@@ -1,0 +1,6 @@
+﻿ee\_extra.Spectral.core.tasseledCap
+===================================
+
+.. currentmodule:: ee_extra.Spectral.core
+
+.. autofunction:: tasseledCap

--- a/ee_extra/Spectral/core.py
+++ b/ee_extra/Spectral/core.py
@@ -212,7 +212,7 @@ def tasseledCap(
 
     Args:
         x : Image or Image Collection to calculate tasseled cap components for. Must 
-        belong to a supported platform.
+            belong to a supported platform.
 
     Returns:
         Image or Image Collection with the tasseled cap components as new bands.
@@ -245,7 +245,7 @@ def tasseledCap(
         >>> import ee
         >>> from ee_extra.Spectral.core import tasseledCap
         >>> ee.Initialize()
-        >>> img = ee.Image("")
+        >>> img = ee.Image("LANDSAT/LT05/C01/T1/LT05_044034_20081011")
         >>> img = tasseledCap(img)
     """
     platformDict = _get_platform_STAC(x)

--- a/ee_extra/Spectral/core.py
+++ b/ee_extra/Spectral/core.py
@@ -196,10 +196,10 @@ def listIndices(online: bool = False) -> list:
 def tasseledCap(
     x: Union[ee.Image, ee.ImageCollection]
 ) -> Union[ee.Image, ee.ImageCollection]:
-    """Calculates tasseled cap brightness, wetness, and greeness components for an image 
+    """Calculates tasseled cap brightness, wetness, and greeness components for an image
     or image collection.
 
-    Tasseled cap transformations are applied using coefficients published for these 
+    Tasseled cap transformations are applied using coefficients published for these
     supported platforms:
 
     * Sentinel-2 MSI Level 1C [1]_
@@ -211,7 +211,7 @@ def tasseledCap(
     * MODIS NBAR [7]_
 
     Args:
-        x : Image or Image Collection to calculate tasseled cap components for. Must 
+        x : Image or Image Collection to calculate tasseled cap components for. Must
             belong to a supported platform.
 
     Returns:

--- a/ee_extra/Spectral/core.py
+++ b/ee_extra/Spectral/core.py
@@ -196,7 +196,7 @@ def listIndices(online: bool = False) -> list:
 def tasseledCap(
     x: Union[ee.Image, ee.ImageCollection]
 ) -> Union[ee.Image, ee.ImageCollection]:
-    """Calculates tasseled cap brightness, wetness, and greeness components for an image
+    """Calculates tasseled cap brightness, wetness, and greenness components for an image
     or image collection.
 
     Tasseled cap transformations are applied using coefficients published for these

--- a/ee_extra/Spectral/core.py
+++ b/ee_extra/Spectral/core.py
@@ -12,6 +12,7 @@ from ee_extra.Spectral.utils import (
     _get_indices,
     _get_kernel_image,
     _get_kernel_parameters,
+    _get_tc_coefficients,
     _remove_none_dict,
 )
 from ee_extra.STAC.utils import _get_platform_STAC
@@ -190,3 +191,78 @@ def listIndices(online: bool = False) -> list:
         ['BNDVI','CIG','CVI','EVI','EVI2','GBNDVI','GNDVI',...]
     """
     return list(_get_indices(online).keys())
+
+
+def tasseledCap(
+    x: Union[ee.Image, ee.ImageCollection]
+) -> Union[ee.Image, ee.ImageCollection]:
+    """Calculates tasseled cap brightness, wetness, and greeness components for an image 
+    or image collection.
+
+    Tasseled cap transformations are applied using coefficients published for these 
+    supported platforms:
+
+    * Sentinel-2 MSI Level 1C [1]_
+    * Landsat 8 OLI TOA [2]_
+    * Landsat 7 ETM+ TOA [3]_
+    * Landsat 5 TM Raw DN [4]_
+    * Landsat 4 TM Raw DN [5]_
+    * Landsat 4 TM Surface Reflectance [6]_
+    * MODIS NBAR [7]_
+
+    Args:
+        x : Image or Image Collection to calculate tasseled cap components for. Must 
+        belong to a supported platform.
+
+    Returns:
+        Image or Image Collection with the tasseled cap components as new bands.
+
+    References:
+        .. [1] Shi, T., & Xu, H. (2019). Derivation of Tasseled Cap Transformation
+           Coefficients for Sentinel-2 MSI At-Sensor Reflectance Data. IEEE Journal
+           of Selected Topics in Applied Earth Observations and Remote Sensing, 1–11.
+           doi:10.1109/jstars.2019.2938388
+        .. [2] Baig, M.H.A., Zhang, L., Shuai, T. and Tong, Q., 2014. Derivation of a
+           tasselled cap transformation based on Landsat 8 at-satellite reflectance.
+           Remote Sensing Letters, 5(5), pp.423-431.
+        .. [3] Huang, C., Wylie, B., Yang, L., Homer, C. and Zylstra, G., 2002.
+           Derivation of a tasselled cap transformation based on Landsat 7 at-satellite
+           reflectance. International journal of remote sensing, 23(8), pp.1741-1748.
+        .. [4] Crist, E.P., Laurin, R. and Cicone, R.C., 1986, September. Vegetation and
+           soils information contained in transformed Thematic Mapper data. In
+           Proceedings of IGARSS’86 symposium (pp. 1465-1470). Paris: European Space
+           Agency Publications Division.
+        .. [5] Crist, E.P. and Cicone, R.C., 1984. A physically-based transformation of
+           Thematic Mapper data---The TM Tasseled Cap. IEEE Transactions on Geoscience
+           and Remote sensing, (3), pp.256-263.
+        .. [6] Crist, E.P., 1985. A TM tasseled cap equivalent transformation for
+           reflectance factor data. Remote sensing of Environment, 17(3), pp.301-306.
+        .. [7] Lobser, S.E. and Cohen, W.B., 2007. MODIS tasselled cap: land cover
+           characteristics expressed through transformed MODIS data. International
+           Journal of Remote Sensing, 28(22), pp.5079-5101.
+
+    Examples:
+        >>> import ee
+        >>> from ee_extra.Spectral.core import tasseledCap
+        >>> ee.Initialize()
+        >>> img = ee.Image("")
+        >>> img = tasseledCap(img)
+    """
+    platformDict = _get_platform_STAC(x)
+    coeffs = _get_tc_coefficients(platformDict)
+
+    def calculateAndAddComponents(img: ee.Image) -> ee.Image:
+        """Calculates tasseled cap components for a single image and adds them as new bands."""
+        img = img.select(coeffs["bands"])
+        components = [
+            img.multiply(coeffs[comp]).reduce(ee.Reducer.sum()).rename(comp)
+            for comp in ["TCB", "TCG", "TCW"]
+        ]
+        return img.addBands(components)
+
+    if isinstance(x, ee.ImageCollection):
+        x = x.map(calculateAndAddComponents)
+    elif isinstance(x, ee.Image):
+        x = calculateAndAddComponents(x)
+
+    return x

--- a/ee_extra/Spectral/utils.py
+++ b/ee_extra/Spectral/utils.py
@@ -252,13 +252,13 @@ def _get_tc_coefficients(platformDict: dict) -> dict:
 
     Coefficients are provided for the following platforms:
 
-    * Sentinel-2 MSI Level 1C [1]_
-    * Landsat 8 OLI TOA [2]_
-    * Landsat 7 ETM+ TOA [3]_
-    * Landsat 5 TM Raw DN [4]_
+    # * Sentinel-2 MSI Level 1C [1]_
+    # * Landsat 8 OLI TOA [2]_
+    # * Landsat 7 ETM+ TOA [3]_
+    # * Landsat 5 TM Raw DN [4]_
     * Landsat 4 TM Raw DN [5]_
     * Landsat 4 TM Surface Reflectance [6]_
-    * MODIS NBAR [7]_
+    # * MODIS NBAR [7]_
 
     Args:
         platformDict : Dictionary retrieved from the _get_STAC_platform() method.
@@ -379,10 +379,10 @@ def _get_tc_coefficients(platformDict: dict) -> dict:
     }
 
     LANDSAT4_SR = {
-        "bands": ("B1", "B2", "B3", "B4", "B5", "B7"),
+        "bands": ("SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B7"),
         "TCB": (0.2043, 0.4158, 0.5524, 0.5741, 0.3124, 0.2303),
-        "TCG": (-0.1603, -0.2819, -0.4934, 0.7940, 0.0002, 0.1446),
-        "TCW": (0.0315, 0.2021, 0.3102, 0.1594, 0.6806, -0.6109),
+        "TCG": (-0.1603, -0.2819, -0.4934, 0.7940, -0.0002, -0.1446),
+        "TCW": (0.0315, 0.2021, 0.3102, 0.1594, -0.6806, -0.6109),
     }
 
     LANDSAT5_DN = {

--- a/ee_extra/Spectral/utils.py
+++ b/ee_extra/Spectral/utils.py
@@ -252,19 +252,20 @@ def _get_tc_coefficients(platformDict: dict) -> dict:
 
     Coefficients are provided for the following platforms:
 
-    # * Sentinel-2 MSI Level 1C [1]_
-    # * Landsat 8 OLI TOA [2]_
-    # * Landsat 7 ETM+ TOA [3]_
-    # * Landsat 5 TM Raw DN [4]_
+    * Sentinel-2 MSI Level 1C [1]_
+    * Landsat 8 OLI TOA [2]_
+    * Landsat 7 ETM+ TOA [3]_
+    * Landsat 5 TM Raw DN [4]_
     * Landsat 4 TM Raw DN [5]_
     * Landsat 4 TM Surface Reflectance [6]_
-    # * MODIS NBAR [7]_
+    * MODIS NBAR [7]_
 
     Args:
         platformDict : Dictionary retrieved from the _get_STAC_platform() method.
 
     Returns:
-        Map dictionary for the ee.Image.expression() method.
+        Map dictionary with band names and corresponding coefficients for brightness
+        greenness, and wetness. 
 
     Raises:
         Exception : If the platform has no supported coefficients.

--- a/ee_extra/Spectral/utils.py
+++ b/ee_extra/Spectral/utils.py
@@ -240,3 +240,196 @@ def _get_kernel_parameters(
     }
 
     return kernelParameters
+
+
+def _get_tc_coefficients(platformDict: dict) -> dict:
+    """Gets the platform-specific coefficient dictionary required for tasseled cap
+    transformation.
+
+    Platform matching is strict, meaning that data must be at the processing level
+    specified by the reference literature that coefficients were sourced from, e.g.
+    Landsat 8 SR cannot be transformed with Landsat 8 TOA coefficients.
+
+    Coefficients are provided for the following platforms:
+
+    * Sentinel-2 MSI Level 1C [1]_
+    * Landsat 8 OLI TOA [2]_
+    * Landsat 7 ETM+ TOA [3]_
+    * Landsat 5 TM Raw DN [4]_
+    * Landsat 4 TM Raw DN [5]_
+    * Landsat 4 TM Surface Reflectance [6]_
+    * MODIS NBAR [7]_
+
+    Args:
+        platformDict : Dictionary retrieved from the _get_STAC_platform() method.
+
+    Returns:
+        Map dictionary for the ee.Image.expression() method.
+
+    Raises:
+        Exception : If the platform has no supported coefficients.
+
+    References:
+        .. [1] Shi, T., & Xu, H. (2019). Derivation of Tasseled Cap Transformation
+           Coefficients for Sentinel-2 MSI At-Sensor Reflectance Data. IEEE Journal
+           of Selected Topics in Applied Earth Observations and Remote Sensing, 1–11.
+           doi:10.1109/jstars.2019.2938388
+        .. [2] Baig, M.H.A., Zhang, L., Shuai, T. and Tong, Q., 2014. Derivation of a
+           tasselled cap transformation based on Landsat 8 at-satellite reflectance.
+           Remote Sensing Letters, 5(5), pp.423-431.
+        .. [3] Huang, C., Wylie, B., Yang, L., Homer, C. and Zylstra, G., 2002.
+           Derivation of a tasselled cap transformation based on Landsat 7 at-satellite
+           reflectance. International journal of remote sensing, 23(8), pp.1741-1748.
+        .. [4] Crist, E.P., Laurin, R. and Cicone, R.C., 1986, September. Vegetation and
+           soils information contained in transformed Thematic Mapper data. In
+           Proceedings of IGARSS’86 symposium (pp. 1465-1470). Paris: European Space
+           Agency Publications Division.
+        .. [5] Crist, E.P. and Cicone, R.C., 1984. A physically-based transformation of
+           Thematic Mapper data---The TM Tasseled Cap. IEEE Transactions on Geoscience
+           and Remote sensing, (3), pp.256-263.
+        .. [6] Crist, E.P., 1985. A TM tasseled cap equivalent transformation for
+           reflectance factor data. Remote sensing of Environment, 17(3), pp.301-306.
+        .. [7] Lobser, S.E. and Cohen, W.B., 2007. MODIS tasselled cap: land cover
+           characteristics expressed through transformed MODIS data. International
+           Journal of Remote Sensing, 28(22), pp.5079-5101.
+    """
+
+    SENTINEL2_1C = {
+        "bands": (
+            "B1",
+            "B2",
+            "B3",
+            "B4",
+            "B5",
+            "B6",
+            "B7",
+            "B8",
+            "B8A",
+            "B9",
+            "B10",
+            "B11",
+            "B12",
+        ),
+        "TCB": (
+            0.2381,
+            0.2569,
+            0.2934,
+            0.3020,
+            0.3099,
+            0.3740,
+            0.4180,
+            0.3580,
+            0.3834,
+            0.0103,
+            0.0020,
+            0.0896,
+            0.0780,
+        ),
+        "TCG": (
+            -0.2266,
+            -0.2818,
+            -0.3020,
+            -0.4283,
+            -0.2959,
+            0.1602,
+            0.3127,
+            0.3138,
+            0.4261,
+            0.1454,
+            -0.0017,
+            -0.1341,
+            -0.2538,
+        ),
+        "TCW": (
+            0.1825,
+            0.1763,
+            0.1615,
+            0.0486,
+            0.0170,
+            0.0223,
+            0.0219,
+            -0.0755,
+            -0.0910,
+            -0.1369,
+            0.0003,
+            -0.7701,
+            -0.5293,
+        ),
+    }
+
+    LANDSAT8_TOA = {
+        "bands": ("B2", "B3", "B4", "B5", "B6", "B7"),
+        "TCB": (0.3029, 0.2786, 0.4733, 0.5599, 0.5080, 0.1872),
+        "TCG": (-0.2941, -0.2430, -0.5424, 0.7276, 0.0713, -0.1608),
+        "TCW": (0.1511, 0.1973, 0.3283, 0.3407, -0.7117, -0.4559),
+    }
+
+    LANDSAT7_TOA = {
+        "bands": ("B1", "B2", "B3", "B4", "B5", "B7"),
+        "TCB": (0.3561, 0.3972, 0.3904, 0.6966, 0.2286, 0.1596),
+        "TCG": (-0.3344, -0.3544, -0.4556, 0.6966, -0.0242, -0.2630),
+        "TCW": (0.2626, 0.2141, 0.0926, 0.0656, -0.7629, -0.5388),
+    }
+
+    LANDSAT4_DN = {
+        "bands": ("B1", "B2", "B3", "B4", "B5", "B7"),
+        "TCB": (0.3037, 0.2793, 0.4743, 0.5585, 0.5082, 0.1863),
+        "TCG": (-0.2848, -0.2435, -0.5435, 0.7243, 0.0840, -0.1800),
+        "TCW": (0.1509, 0.1973, 0.3279, 0.3406, -0.7112, -0.4572),
+    }
+
+    LANDSAT4_SR = {
+        "bands": ("B1", "B2", "B3", "B4", "B5", "B7"),
+        "TCB": (0.2043, 0.4158, 0.5524, 0.5741, 0.3124, 0.2303),
+        "TCG": (-0.1603, -0.2819, -0.4934, 0.7940, 0.0002, 0.1446),
+        "TCW": (0.0315, 0.2021, 0.3102, 0.1594, 0.6806, -0.6109),
+    }
+
+    LANDSAT5_DN = {
+        "bands": ("B1", "B2", "B3", "B4", "B5", "B7"),
+        "TCB": (0.2909, 0.2493, 0.4806, 0.5568, 0.4438, 0.1706),
+        "TCG": (-0.2728, -0.2174, -0.5508, 0.7221, 0.0733, -0.1648),
+        "TCW": (0.1446, 0.1761, 0.3322, 0.3396, -0.6210, -0.4186),
+    }
+
+    MODIS_NBAR = {
+        "bands": (
+            "Nadir_Reflectance_Band1",
+            "Nadir_Reflectance_Band2",
+            "Nadir_Reflectance_Band3",
+            "Nadir_Reflectance_Band4",
+            "Nadir_Reflectance_Band5",
+            "Nadir_Reflectance_Band6",
+            "Nadir_Reflectance_Band7",
+        ),
+        "TCB": (0.4395, 0.5945, 0.2460, 0.3918, 0.3506, 0.2136, 0.2678),
+        "TCG": (-0.4064, 0.5129, -0.2744, -0.2893, 0.4882, -0.0036, -0.4169),
+        "TCW": (0.1147, 0.2489, 0.2408, 0.3132, -0.3122, -0.6416, -0.5087),
+    }
+
+    platformCoeffs = {
+        "COPERNICUS/S2": SENTINEL2_1C,
+        "MODIS/006/MCD43A4": MODIS_NBAR,
+        "LANDSAT/LC08/C01/T1_TOA": LANDSAT8_TOA,
+        "LANDSAT/LC08/C01/T1_RT_TOA": LANDSAT8_TOA,
+        "LANDSAT/LC08/C01/T2_TOA": LANDSAT8_TOA,
+        "LANDSAT/LE07/C01/T1_TOA": LANDSAT7_TOA,
+        "LANDSAT/LE07/C01/T1_RT_TOA": LANDSAT7_TOA,
+        "LANDSAT/LE07/C01/T2_TOA": LANDSAT7_TOA,
+        "LANDSAT/LT05/C01/T1": LANDSAT5_DN,
+        "LANDSAT/LT05/C01/T2": LANDSAT5_DN,
+        "LANDSAT/LT04/C02/T1_L2": LANDSAT4_SR,
+        "LANDSAT/LT04/C02/T2_L2": LANDSAT4_SR,
+        "LANDSAT/LT04/C01/T1": LANDSAT4_DN,
+        "LANDSAT/LT04/C01/T2": LANDSAT4_DN,
+    }
+
+    platform = platformDict["platform"]
+
+    if platform not in list(platformCoeffs.keys()):
+        raise Exception(
+            "Sorry, satellite platform not supported for tasseled cap transformation! Use one of "
+            + str(list(platformCoeffs.keys()))
+        )
+
+    return platformCoeffs[platform]

--- a/tests/test_Spectral.py
+++ b/tests/test_Spectral.py
@@ -32,6 +32,23 @@ datasets = [
     "MODIS/006/MCD43A4",
 ]
 
+tasseledcap_datasets = [
+    "COPERNICUS/S2",
+    "MODIS/006/MCD43A4",
+    "LANDSAT/LC08/C01/T1_TOA",
+    "LANDSAT/LC08/C01/T1_RT_TOA",
+    "LANDSAT/LC08/C01/T2_TOA",
+    "LANDSAT/LE07/C01/T1_TOA",
+    "LANDSAT/LE07/C01/T1_RT_TOA",
+    "LANDSAT/LE07/C01/T2_TOA",
+    "LANDSAT/LT05/C01/T1",
+    "LANDSAT/LT05/C01/T2",
+    "LANDSAT/LT04/C02/T1_L2",
+    "LANDSAT/LT04/C02/T2_L2",
+    "LANDSAT/LT04/C01/T1",
+    "LANDSAT/LT04/C01/T2",
+]
+
 
 class Test(unittest.TestCase):
     """Tests for ee_extra package."""
@@ -55,6 +72,16 @@ class Test(unittest.TestCase):
         """Test the listIndices() method"""
         self.assertIsInstance(listIndices(), list)
         self.assertIsInstance(listIndices(True), list)
+
+    def test_tasseledCap(self):
+        """Test the tasseledCap() method"""
+        for dataset in tasseledcap_datasets:
+            with self.subTest(i=dataset):
+                x = ee.ImageCollection(dataset).filterBounds(point).limit(10)
+                self.assertIsInstance(tasseledCap(x), ee.imagecollection.ImageCollection)
+
+                x = ee.ImageCollection(dataset).filterBounds(point).first()
+                self.assertIsInstance(tasseledCap(x), ee.image.Image)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fix #5 by adding `tasseledCap` function to `Spectral` module for calculating brightness, greenness, and wetness from Sentinel-2, MODIS, and Landsat 4-8 images and image collections 
- Add utility function for matching platforms to tasseled cap coefficients
- Update tests and docs to include `tasseledCap`

Let me know if any changes are needed :)