### PR TITLE
Migrate `panSharpening` module from `eemont`

### DIFF
--- a/docs/modules/Algorithms.rst
+++ b/docs/modules/Algorithms.rst
@@ -1,0 +1,21 @@
+Extra.Algorithms
+================
+
+.. currentmodule:: ee_extra.Algorithms.core
+
+.. autosummary::
+    :toctree: stubs
+
+    panSharpen
+
+.. currentmodule:: ee_extra.Algorithms.panSharpening
+
+.. autosummary::
+    :toctree: stubs
+
+    listSharpeners
+    getSharpener
+    SFIM
+    HPFA
+    PCS
+    SM

--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -15,6 +15,7 @@ Welcome to the eeExtra API Reference!
    Spectral
    STAC
    TimeSeries
+   Algorithms
    
 Extra.Image
 -----------
@@ -68,6 +69,23 @@ Extra.QA
 
    preprocess
 
+.. currentmodule:: ee_extra.QA.metrics
+
+.. autosummary::
+
+   listMetrics
+   getMetrics
+   MSE
+   RMSE
+   RASE
+   ERGAS
+   DIV
+   bias
+   CC
+   CML
+   CMC
+   UIQI
+
 Extra.Spectral
 --------------
 
@@ -104,3 +122,23 @@ Extra.TimeSeries
 
    getTimeSeriesByRegion
    getTimeSeriesByRegions
+
+Extra.Algorithms
+----------------
+
+.. currentmodule:: ee_extra.Algorithms.core
+
+.. autosummary::
+
+   panSharpen
+
+.. currentmodule:: ee_extra.Algorithms.panSharpening
+
+.. autosummary::
+
+   listSharpeners
+   getSharpener
+   SFIM
+   HPFA
+   PCS
+   SM

--- a/ee_extra/Algorithms/core.py
+++ b/ee_extra/Algorithms/core.py
@@ -1,0 +1,32 @@
+from typing import Any, TypeVar
+
+import ee
+
+from ee_extra.Algorithms.panSharpening import _panSharpen
+
+ImageLike = TypeVar("ImageLike", ee.Image, ee.ImageCollection)
+
+
+def panSharpen(img: ImageLike, method: str = "SFIM", **kwargs: Any) -> ImageLike:
+    """Apply panchromatic sharpening to an Image or ImageCollection.
+
+    Args:
+        img : Image or ImageCollection to sharpen.
+        method : The sharpening algorithm to apply. Current options are "SFIM" (Smoothing
+            Filter-based Intensity Modulation), "HPFA" (High Pass Filter Addition), "PCS"
+            (Principal Component Substitution), and "SM" (simple mean).
+        kwargs : Keyword arguments passed to ee.Image.reduceRegion() such as "geometry",
+            "maxPixels", "bestEffort", etc. These arguments are only used for PCS sharpening
+            and quality assessments.
+
+    Returns:
+        The Image with all sharpenable bands sharpened to the panchromatic resolution.
+
+    Examples:
+    >>> import ee
+    >>> from ee_extra.Algorithms.core import panSharpen
+    >>> ee.Initialize()
+    >>> img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
+    >>> sharp = panSharpen(img, method="HPFA", maxPixels=1e13)
+    """
+    return _panSharpen(img, method, **kwargs)

--- a/ee_extra/Algorithms/core.py
+++ b/ee_extra/Algorithms/core.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Sequence, Optional
+from typing import Any, TypeVar, List, Optional, Union
 
 import ee
 
@@ -7,7 +7,13 @@ from ee_extra.Algorithms.panSharpening import _panSharpen
 ImageLike = TypeVar("ImageLike", ee.Image, ee.ImageCollection)
 
 
-def panSharpen(img: ImageLike, method: str = "SFIM", qa: Optional[Sequence[str]] = None, prefix: str="ee_extra", **kwargs: Any) -> ImageLike:
+def panSharpen(
+    img: ImageLike,
+    method: str = "SFIM",
+    qa: Optional[Union[str, List[str]]] = None,
+    prefix: str = "ee_extra",
+    **kwargs: Any
+) -> ImageLike:
     """Apply panchromatic sharpening to an Image or ImageCollection.
 
     Args:
@@ -15,17 +21,17 @@ def panSharpen(img: ImageLike, method: str = "SFIM", qa: Optional[Sequence[str]]
         method : The sharpening algorithm to apply. Current options are "SFIM" (Smoothing
             Filter-based Intensity Modulation), "HPFA" (High Pass Filter Addition), "PCS"
             (Principal Component Substitution), and "SM" (simple mean).
-        qa : One or more optional quality metrics to calculate and set as properties on 
+        qa : One or more optional quality metrics to calculate and set as properties on
             the sharpened image. See ee_extra.QA.metrics.listMetrics().keys() for a list
             of supported metrics.
-        prefix : A prefix for any new properties. For example, quality metrics will be 
+        prefix : A prefix for any new properties. For example, quality metrics will be
             set as `prefix:metric`, e.g. `ee_extra:RMSE`.
         kwargs : Keyword arguments passed to ee.Image.reduceRegion() such as "geometry",
             "maxPixels", "bestEffort", etc. These arguments are only used for PCS sharpening
             and quality assessments.
 
     Returns:
-        The Image with all sharpenable bands sharpened to the panchromatic resolution.
+        The Image or Image Collection with all sharpenable bands sharpened to the panchromatic resolution.
 
     Examples:
     >>> import ee

--- a/ee_extra/Algorithms/core.py
+++ b/ee_extra/Algorithms/core.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Sequence, Optional
 
 import ee
 
@@ -7,7 +7,7 @@ from ee_extra.Algorithms.panSharpening import _panSharpen
 ImageLike = TypeVar("ImageLike", ee.Image, ee.ImageCollection)
 
 
-def panSharpen(img: ImageLike, method: str = "SFIM", **kwargs: Any) -> ImageLike:
+def panSharpen(img: ImageLike, method: str = "SFIM", qa: Optional[Sequence[str]] = None, prefix: str="ee_extra", **kwargs: Any) -> ImageLike:
     """Apply panchromatic sharpening to an Image or ImageCollection.
 
     Args:
@@ -15,6 +15,11 @@ def panSharpen(img: ImageLike, method: str = "SFIM", **kwargs: Any) -> ImageLike
         method : The sharpening algorithm to apply. Current options are "SFIM" (Smoothing
             Filter-based Intensity Modulation), "HPFA" (High Pass Filter Addition), "PCS"
             (Principal Component Substitution), and "SM" (simple mean).
+        qa : One or more optional quality metrics to calculate and set as properties on 
+            the sharpened image. See ee_extra.QA.metrics.listMetrics().keys() for a list
+            of supported metrics.
+        prefix : A prefix for any new properties. For example, quality metrics will be 
+            set as `prefix:metric`, e.g. `ee_extra:RMSE`.
         kwargs : Keyword arguments passed to ee.Image.reduceRegion() such as "geometry",
             "maxPixels", "bestEffort", etc. These arguments are only used for PCS sharpening
             and quality assessments.
@@ -27,6 +32,6 @@ def panSharpen(img: ImageLike, method: str = "SFIM", **kwargs: Any) -> ImageLike
     >>> from ee_extra.Algorithms.core import panSharpen
     >>> ee.Initialize()
     >>> img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
-    >>> sharp = panSharpen(img, method="HPFA", maxPixels=1e13)
+    >>> sharp = panSharpen(img, method="HPFA", qa=["RMSE", "ERGAS"], maxPixels=1e13)
     """
-    return _panSharpen(img, method, **kwargs)
+    return _panSharpen(img, method, qa, prefix, **kwargs)

--- a/ee_extra/Algorithms/core.py
+++ b/ee_extra/Algorithms/core.py
@@ -34,10 +34,10 @@ def panSharpen(
         The Image or Image Collection with all sharpenable bands sharpened to the panchromatic resolution.
 
     Examples:
-    >>> import ee
-    >>> from ee_extra.Algorithms.core import panSharpen
-    >>> ee.Initialize()
-    >>> img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
-    >>> sharp = panSharpen(img, method="HPFA", qa=["RMSE", "ERGAS"], maxPixels=1e13)
+        >>> import ee
+        >>> from ee_extra.Algorithms.core import panSharpen
+        >>> ee.Initialize()
+        >>> img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
+        >>> sharp = panSharpen(img, method="HPFA", qa=["RMSE", "ERGAS"], maxPixels=1e13)
     """
     return _panSharpen(img, method, qa, prefix, **kwargs)

--- a/ee_extra/Algorithms/panSharpening.py
+++ b/ee_extra/Algorithms/panSharpening.py
@@ -95,7 +95,7 @@ def _panSharpen(
 
         sharpened: ee.Image = sharpener(source, pan, **kwargs)
 
-        sharpened = ee.Image(sharpened.copyProperties(source, pan.propertyNames()))
+        sharpened = ee.Image(ee.Element.copyProperties(sharpened, source, pan.propertyNames()))
         sharpened = sharpened.updateMask(source.mask())
 
         if qa is not None:

--- a/ee_extra/Algorithms/panSharpening.py
+++ b/ee_extra/Algorithms/panSharpening.py
@@ -1,0 +1,315 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Sequence, Type, TypeVar
+
+import ee
+
+from ee_extra.Spectral.core import matchHistogram
+from ee_extra.STAC.utils import _get_platform_STAC
+from ee_extra.utils import _filter_image_bands, _get_case_insensitive_close_matches
+
+ImageLike = TypeVar("ImageLike", ee.Image, ee.ImageCollection)
+
+L7_BANDS = {"sharpenable": ["B1", "B2", "B3", "B4", "B5", "B7"], "pan": "B8"}
+L8_BANDS = {"sharpenable": ["B2", "B3", "B4", "B5", "B6", "B7"], "pan": "B8"}
+PLATFORM_BANDS = {
+    "LANDSAT/LC08/C01/T1_TOA": L8_BANDS,
+    "LANDSAT/LC08/C01/T1_RT_TOA": L8_BANDS,
+    "LANDSAT/LC08/C01/T2_TOA": L8_BANDS,
+    "LANDSAT/LC08/C01/T1_RT": L8_BANDS,
+    "LANDSAT/LO08/C01/T1": L8_BANDS,
+    "LANDSAT/LC08/C01/T1": L8_BANDS,
+    "LANDSAT/LO08/C01/T2": L8_BANDS,
+    "LANDSAT/LC08/C01/T2": L8_BANDS,
+    "LANDSAT/LE07/C01/T1_TOA": L7_BANDS,
+    "LANDSAT/LE07/C01/T1_RT_TOA": L7_BANDS,
+    "LANDSAT/LE07/C01/T2_TOA": L7_BANDS,
+    "LANDSAT/LE07/C01/T1_RT": L7_BANDS,
+    "LANDSAT/LE07/C01/T1": L7_BANDS,
+    "LANDSAT/LE07/C01/T2": L7_BANDS,
+}
+
+
+def _panSharpen(img: ImageLike, method: str, **kwargs: Any) -> ImageLike:
+    """Apply panchromatic sharpening to an Image or ImageCollection.
+
+    Args:
+        source : Image or ImageCollection to sharpen.
+        method : The sharpening algorithm to apply. Current options are "SFIM" (Smoothing
+            Filter-based Intensity Modulation), "HPFA" (High Pass Filter Addition), "PCS"
+            (Principal Component Substitution), and "SM" (simple mean).
+        **kwargs : Keyword arguments passed to ee.Image.reduceRegion() such as
+            "geometry", "maxPixels", "bestEffort", etc. These arguments are only used for
+            PCS sharpening.
+
+    Returns:
+        The Image or ImageCollection with all sharpenable bands sharpened to the panchromatic resolution.
+    """
+
+    def get_platform_bands(img: ee.Image) -> Dict[str, Sequence[str]]:
+        """Get the correct platform bands for sharpening supported platforms.
+
+        Args:
+            source : An Image or ImageCollection identify a platform function for.
+
+        Returns:
+            A function that accepts Images and ImageCollections from the source platform.
+
+        Raises:
+            AttributeError : If the platform is unsupported.
+        """
+        platform_dict = _get_platform_STAC(img)
+        platforms = list(PLATFORM_BANDS.keys())
+        platform = platform_dict["platform"]
+
+        if platform not in platforms:
+            raise AttributeError(
+                "Sharpening is not supported for the {} platform. Use one of the following platforms: {}".format(
+                    platform, platforms
+                )
+            )
+
+        return PLATFORM_BANDS[platform]
+
+    def apply_sharpening(img: ee.Image) -> ee.Image:
+        """Identify and apply the correct sharpening algorithm to an Image.
+
+        Args:
+            img : Image to sharpen.
+
+        Returns:
+            The Image with all sharpenable bands sharpened to the panchromatic resolution.
+        """
+        source = _filter_image_bands(img, platform_bands["sharpenable"])
+        pan = img.select(platform_bands["pan"])
+
+        sharpened: ee.Image = sharpener(source, pan, **kwargs)
+
+        sharpened = ee.Image(sharpened.copyProperties(source, pan.propertyNames()))
+        sharpened = sharpened.updateMask(source.mask())
+
+        return sharpened
+
+    sharpener = getSharpener(method)
+    platform_bands = get_platform_bands(img)
+
+    if isinstance(img, ee.image.Image):
+        sharpened = apply_sharpening(img)
+    elif isinstance(img, ee.imagecollection.ImageCollection):
+        sharpened = img.map(apply_sharpening)
+
+    return sharpened
+
+
+def listSharpeners() -> Dict[str, Type["Sharpener"]]:
+    """Get the name and class of all pan-sharpening algorithms.
+
+    Returns:
+        A dictionary of Sharpener subclasses with class names as keys and classes as
+        values.
+    """
+    sharpeners: List[Type[Sharpener]] = Sharpener.__subclasses__()
+    return {sharpener.__name__: sharpener for sharpener in sharpeners}
+
+
+def getSharpener(name: str) -> Type["Sharpener"]:
+    """Return a pan-sharpening algorithm that matches a name.
+
+    Args:
+        name : The name of a sharpener, e.g. SFIM.
+
+    Returns:
+        The Sharpener subclass.
+    """
+    options = listSharpeners()
+    keys = list(options.keys())
+
+    try:
+        sharpener = options[name]
+    except KeyError:
+        close_matches = _get_case_insensitive_close_matches(name, keys, n=3)
+        hint = " Close matches: {}.".format(close_matches) if close_matches else ""
+
+        raise AttributeError(
+            '"{}" is not a supported sharpening algorithm. Choose from {}.{}'.format(
+                name, keys, hint
+            )
+        )
+    return sharpener
+
+
+class Sharpener(ABC):
+    """The abstract class that is implemented by all sharpening algorithms."""
+
+    def __new__(cls, img: ee.Image, pan: ee.Image, **kwargs: Any) -> ee.Image:
+        """Apply pansharpening and return the sharpened image when the class is
+        instantiated.
+        """
+        return cls._sharpen(img, pan, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def _sharpen(img: ee.Image, pan: ee.Image, **kwargs: Any) -> ee.Image:
+        """Abstract method implemented by each Sharpener that applies sharpening."""
+        return
+
+
+class SFIM(Sharpener):
+    """The Smoothing Filter-based Intensity Modulation (SFIM) sharpener."""
+
+    @staticmethod
+    def _sharpen(img: ee.Image, pan: ee.Image, **kwargs: Any) -> ee.Image:
+        """Apply Smoothing Filter-based Intensity Modulation (SFIM) sharpening.
+
+        Args:
+            img : Image to sharpen with only sharpenable bands selected.
+            pan : Image with only the panchromatic band selected.
+            kwargs : Additional keyword arguments. Currently unused.
+
+        Returns:
+            The Image with all sharpenable bands sharpened to the panchromatic
+            resolution.
+
+        References:
+            Liu, J. G. (2000). Smoothing Filter-based Intensity Modulation: A
+                spectral preserve image fusion technique for improving spatial
+                details. International Journal of Remote Sensing, 21(18), 3461–3472.
+                https://doi.org/10.1080/014311600750037499
+        """
+        img_scale = img.projection().nominalScale()
+        pan_scale = pan.projection().nominalScale()
+        kernel_width = img_scale.divide(pan_scale)
+        kernel = ee.Kernel.square(radius=kernel_width.divide(2))
+        pan_smooth = pan.reduceNeighborhood(reducer=ee.Reducer.mean(), kernel=kernel)
+
+        img = img.resample("bicubic")
+        sharp = img.multiply(pan).divide(pan_smooth)
+        sharp = sharp.reproject(pan.projection())
+        return sharp
+
+
+class HPFA(Sharpener):
+    """The High Pass Filter Addition (HPFA) sharpener."""
+
+    @staticmethod
+    def _sharpen(img: ee.Image, pan: ee.Image, **kwargs: Any) -> ee.Image:
+        """Apply High-Pass Filter Addition sharpening.
+
+        Args:
+            img : Image to sharpen with only sharpenable bands selected.
+            pan : Image with only the panchromatic band selected.
+            kwargs : Additional keyword arguments. Currently unused.
+
+        Returns:
+            The Image with all sharpenable bands sharpened to the panchromatic
+            resolution.
+
+        References:
+            Gangkofner, U. G., Pradhan, P. S., & Holcomb, D. W. (2008). Optimizing
+                the High-Pass Filter Addition Technique for Image Fusion.
+                Photogrammetric Engineering & Remote Sensing, 74(9), 1107–1118.
+                https://doi.org/10.14358/pers.74.9.1107
+        """
+        img_scale = img.projection().nominalScale()
+        pan_scale = pan.projection().nominalScale()
+        kernel_width = img_scale.divide(pan_scale).multiply(2).add(1)
+
+        img = img.resample("bicubic")
+
+        center_val = kernel_width.pow(2).subtract(1)
+        center = kernel_width.divide(2).int()
+        kernel_row = ee.List.repeat(-1, kernel_width)
+        kernel = ee.List.repeat(kernel_row, kernel_width)
+        kernel = kernel.set(center, ee.List(kernel.get(center)).set(center, center_val))
+        kernel = ee.Kernel.fixed(weights=kernel, normalize=True)
+
+        pan_hpf = pan.convolve(kernel)
+        sharp = img.add(pan_hpf)
+        sharp = sharp.reproject(pan.projection())
+
+        return sharp
+
+
+class PCS(Sharpener):
+    """The Principal Component Substitution (PCS) sharpener."""
+
+    @staticmethod
+    def _sharpen(img: ee.Image, pan: ee.Image, **kwargs: Any) -> ee.Image:
+        """Apply Principal Component Substitution (PCS) sharpening.
+
+        Args:
+            img : Image to sharpen with only sharpenable bands selected.
+            pan : Image with only the panchromatic band selected.
+
+        Returns:
+            The Image with all sharpenable bands sharpened to the panchromatic
+            resolution.
+        """
+        img = img.resample("bicubic").reproject(pan.projection())
+        band_names = img.bandNames()
+
+        band_means = img.reduceRegion(ee.Reducer.mean(), **kwargs)
+        img_means = band_means.toImage(band_names)
+        img_centered = img.subtract(img_means)
+
+        img_arr = img_centered.toArray()
+        covar = img_arr.reduceRegion(ee.Reducer.centeredCovariance(), **kwargs)
+        covar_arr = ee.Array(covar.get("array"))
+        eigens = covar_arr.eigen()
+        eigenvectors = eigens.slice(1, 1)
+        img_arr_2d = img_arr.toArray(1)
+
+        principal_components = (
+            ee.Image(eigenvectors)
+            .matrixMultiply(img_arr_2d)
+            .arrayProject([0])
+            .arrayFlatten([band_names])
+        )
+
+        pc1_name = principal_components.bandNames().get(0)
+
+        # A dictionary can't use an ee.ComputedObject as a key, so set temporary band names
+        pc1 = principal_components.select([pc1_name]).rename(["PC1"])
+        pan = pan.rename(["pan"])
+
+        pan_matched = matchHistogram(
+            source=pan,
+            target=pc1,
+            bands={"pan": "PC1"},
+            geometry=kwargs.get("geometry"),
+        ).rename([pc1_name])
+
+        principal_components = principal_components.addBands(
+            pan_matched, overwrite=True
+        )
+
+        sharp_centered = (
+            ee.Image(eigenvectors)
+            .matrixSolve(principal_components.toArray().toArray(1))
+            .arrayProject([0])
+            .arrayFlatten([band_names])
+        )
+        sharp = sharp_centered.add(img_means)
+
+        return sharp
+
+
+class SM(Sharpener):
+    """The Simple Mean (SM) sharpener."""
+
+    @staticmethod
+    def _sharpen(img: ee.Image, pan: ee.Image, **kwargs: Any) -> ee.Image:
+        """Apply Simple Mean (SM) sharpening.
+
+        Args:
+            img : Image to sharpen with only sharpenable bands selected.
+            pan : Image with only the panchromatic band selected.
+            kwargs : Additional keyword arguments. Currently unused.
+
+        Returns:
+            The Image with all sharpenable bands sharpened to the panchromatic
+            resolution.
+        """
+        img = img.resample("bicubic")
+        sharp = img.add(pan).multiply(0.5)
+        sharp = sharp.reproject(pan.projection())
+        return sharp

--- a/ee_extra/utils.py
+++ b/ee_extra/utils.py
@@ -1,8 +1,9 @@
 import difflib
 import json
 import os
-from typing import Any, Optional, Union, List
+from typing import Any, Optional, List, Sequence
 
+import ee
 import pkg_resources
 
 
@@ -49,3 +50,19 @@ def _get_case_insensitive_close_matches(
         word.lower(), [p.lower() for p in possibilities], n, cutoff
     )
     return [p for p in possibilities if p.lower() in lower_matches]
+
+
+def _filter_image_bands(img: ee.Image, keep_bands: Sequence[str]) -> ee.Image:
+    """Remove Image bands that aren't in list of bands to keep. Essentially a version of
+    ee.Image.select() that doesn't fail if bands are missing.
+
+    Args:
+        img : An Image to select bands from.
+        keep_bands : A list of band names to keep in the Image. All other bands will be
+            removed. Any specified bands that do not exist will be ignored.
+
+    Returns:
+        The image with specified bands selected.
+    """
+    bands = img.bandNames().filter(ee.Filter.inList("item", keep_bands))
+    return img.select(bands)

--- a/tests/test_Algorithms.py
+++ b/tests/test_Algorithms.py
@@ -1,0 +1,51 @@
+import unittest
+
+import ee
+
+from ee_extra.Algorithms.core import panSharpen
+
+ee.Initialize()
+
+
+class Test(unittest.TestCase):
+    """Tests for Algorithms module."""
+
+    def test_pansharpen_with_image(self):
+        """Pansharpening an image should return an image."""
+        img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
+        sharp = panSharpen(img)
+        self.assertIsInstance(sharp, ee.Image)
+
+    def test_pansharpen_with_collection(self):
+        """Pansharpening an collection should return an collection"""
+        col = ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA").limit(10)
+        sharp = panSharpen(col)
+        self.assertIsInstance(sharp, ee.ImageCollection)
+
+    def test_pansharpen_with_unsupported_platform(self):
+        """Pansharpening an unsupported platform should raise an AttributeError."""
+        unsupp = ee.ImageCollection("COPERNICUS/S2_SR").limit(10)
+        
+        with self.assertRaises(AttributeError):
+            panSharpen(unsupp)
+
+    def test_pansharpen_with_qa(self):
+        """Pansharpening an image or collection with QA metrics should return the input type."""
+        img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
+        sharp = panSharpen(img, qa=["RMSE", "UIQI", "ERGAS"])
+        self.assertIsInstance(sharp, ee.Image)
+
+        col = ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA").limit(10)
+        sharp = panSharpen(col, qa=["RMSE", "UIQI", "ERGAS"])
+        self.assertIsInstance(sharp, ee.ImageCollection)
+
+    def test_pansharpen_with_bad_qa(self):
+        """Pansharpening with invalid QA names should raise an AttributeError"""
+        img = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
+        
+        with self.assertRaises(AttributeError):
+            panSharpen(img, qa=["not_a_real_metric"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_QA.py
+++ b/tests/test_QA.py
@@ -29,8 +29,5 @@ class Test(unittest.TestCase):
         modified = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
 
         for metric in metrics:
-            if metric is ERGAS:
-                value = metric(img, modified, h=30, l=30)
-            else:
-                value = metric(img, modified)
+            value = metric(img, modified)
             self.assertIsInstance(value, (ee.Number, ee.Dictionary))


### PR DESCRIPTION
This PR (along with #29 and #33) closes #28 by adding the `panSharpening` module to `ee_extra.Algorithms`. Four sharpening algorithms (SFIM, PCS, SM, and HPFA) are currently implemented. Docs and tests are also added for the module.

The PR also makes some other changes that arose while adding `panSharpening`:
- Reprojection was added to metrics in the `ee_extra.QA.metrics` module controlled by the `reproject` arg. This should have little or no impact on users who use the metrics independently and simplifies the integration between sharpening and metric calculation. 
- Adding reprojection to metrics allowed the `ERGAS` metric implementation to be simplified so that it no longer requires explicitly passing high and low resolution parameters--these can be derived from the images *before* reprojection takes place within the metric calculation.
- Type hints were fixed in the `ee_extra.QA.metrics` to make `mypy` happy.
- The `_filter_image_bands` function was added to `ee_extra.utils` to help with sharpening. This could be moved into the `ee_extra.Image` module if that seems more appropriate.