### PR TITLE
Only run cron jobs on main fork

### DIFF
--- a/.github/workflows/update_awesome_spectral_indices.yml
+++ b/.github/workflows/update_awesome_spectral_indices.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'r-earthengine' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/update_ee_appshot.yml
+++ b/.github/workflows/update_ee_appshot.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'r-earthengine' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/update_gee_stac_ids.yml
+++ b/.github/workflows/update_gee_stac_ids.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'r-earthengine' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/update_gee_stac_scale_offset.yml
+++ b/.github/workflows/update_gee_stac_scale_offset.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'r-earthengine' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
This PR would close #38 by updating cron job workflows to only run for the main repository owner (not forks).