### PR TITLE
added cloud_score+

### DIFF
--- a/ee_extra/QA/clouds.py
+++ b/ee_extra/QA/clouds.py
@@ -25,9 +25,10 @@ def maskClouds(
         method : Method used to mask clouds.\n
             Available options:
                 - 'cloud_prob' : Use cloud probability.
+                - 'cloud_score+' : Use cloud score+.
                 - 'qa' : Use Quality Assessment band.
             This parameter is ignored for Landsat products.
-        prob : Cloud probability threshold. Valid just for method = 'cloud_prob'. This parameter is ignored for Landsat products.
+        prob : Cloud probability threshold. Valid for method = 'cloud_prob' or 'cloud_score+'. This parameter is ignored for Landsat products.
         maskCirrus : Whether to mask cirrus clouds. Valid just for method = 'qa'. This parameter is ignored for Landsat products.
         maskShadows : Whether to mask cloud shadows. For more info see 'Braaten, J. 2020. Sentinel-2 Cloud Masking with s2cloudless. Google Earth Engine, Community Tutorials'.
         scaledImage : Whether the pixel values are scaled to the range [0,1] (reflectance values). This parameter is ignored for Landsat products.
@@ -43,7 +44,7 @@ def maskClouds(
         Cloud-shadow masked image or image collection.
     """
 
-    validMethods = ["cloud_prob", "qa"]
+    validMethods = ["cloud_prob", "cloud_score+", "qa"]
 
     if method not in validMethods:
         raise Exception(
@@ -59,6 +60,11 @@ def maskClouds(
         def cloud_prob(img):
             clouds = ee.Image(img.get("cloud_mask")).select("probability")
             isCloud = clouds.gte(prob).rename("CLOUD_MASK")
+            return img.addBands(isCloud)
+        
+        def cloud_score(img):
+            clouds = img.select("cs_cdf")
+            isCloud = clouds.lte(1-(prob/100)).rename("CLOUD_MASK")
             return img.addBands(isCloud)
 
         def QA(img):
@@ -128,6 +134,11 @@ def maskClouds(
                     ee.ImageCollection(args), S2Clouds, fil
                 )
                 S2Masked = ee.ImageCollection(S2WithCloudMask).map(cloud_prob).first()
+            elif method == 'cloud_score+':
+                QA_BAND = 'cs_cdf'
+                S2Clouds = ee.ImageCollection('GOOGLE/CLOUD_SCORE_PLUS/V1/S2_HARMONIZED').select(QA_BAND)
+                S2WithCloudMask = ee.ImageCollection(args).linkCollection(S2Clouds, [QA_BAND])
+                S2Masked = ee.ImageCollection(S2WithCloudMask).map(cloud_score).first()
             elif method == "qa":
                 S2Masked = QA(args)
             if cdi != None:
@@ -145,6 +156,11 @@ def maskClouds(
                     args, S2Clouds, fil
                 )
                 S2Masked = ee.ImageCollection(S2WithCloudMask).map(cloud_prob)
+            elif method == 'cloud_score+':
+                QA_BAND = 'cs_cdf'
+                S2Clouds = ee.ImageCollection('GOOGLE/CLOUD_SCORE_PLUS/V1/S2_HARMONIZED').select(QA_BAND)
+                S2WithCloudMask = ee.ImageCollection(args).linkCollection(S2Clouds, [QA_BAND])
+                S2Masked = ee.ImageCollection(S2WithCloudMask).map(cloud_score)
             elif method == "qa":
                 S2Masked = args.map(QA)
             if cdi != None:
@@ -336,3 +352,4 @@ def maskClouds(
             else:
                 masked = x.map(lookup[platformDict["platform"]])
         return masked
+

--- a/ee_extra/QA/clouds.py
+++ b/ee_extra/QA/clouds.py
@@ -347,7 +347,7 @@ def maskClouds(
         if isinstance(x, ee.image.Image):
             masked = lookup[platformDict["platform"]](x)
         elif isinstance(x, ee.imagecollection.ImageCollection):
-            if platformDict["platform"] == "COPERNICUS/S2_SR":
+            if platformDict["platform"] in ["COPERNICUS/S2_SR", "COPERNICUS/S2_SR_HARMONIZED"]:
                 masked = lookup[platformDict["platform"]](x)
             else:
                 masked = x.map(lookup[platformDict["platform"]])


### PR DESCRIPTION
A new cloud mask has been added to GEE. It'd be great to get this added to `ee_extra`, and therefore `eemont`.

This makes use of `.linkCollection()` which is available in the latest version of earthengine-api ('0.1.377'). I was unsure whether it was worth editing the cloud_prob code to use this new method as well. I've left it alone for now.

Here's some code to compare cloud_prob to cloud_score+:

```# -*- coding: utf-8 -*-
"""#cloud score.ipynb

import geemap

import eemont
import ee

#ee.Authenticate()
ee.Initialize()

col = ee.ImageCollection('COPERNICUS/S2_SR')

S2 = ee.ImageCollection('COPERNICUS/S2_SR')

point = ee.Geometry.Point(-2.82,54.04)

date = '2023-04-01'
prob = 50

img = S2.filterBounds(point).closest(date).maskClouds(method='cloud_prob', prob=prob)

img2 = S2.filterBounds(point).closest(date).maskClouds(method='cloud_score+', prob=prob)

viz = {'bands':['B4','B3','B2'], 'min':0,'max':5000}

Map = geemap.Map(center=(54.04,-2.82), zoom=12, height=600)

cloud_prob = geemap.ee_tile_layer(img, viz, 'cloud_prob')
cloud_score = geemap.ee_tile_layer(img2, viz, 'cloud_score+')
Map.split_map(cloud_prob, cloud_score)

Map.add_text(f'cloud_prob {prob}%', position='topleft')
Map.add_text(f'cloud_score+ {prob}%', position='topright')
Map
```
 @davemlz, @csaybar, @aazuspan @KMarkert 