### PR TITLE
Fix cloud masking for COPERNICUS/S2_SR_HARMONIZED

### DIFF
--- a/ee_extra/QA/clouds.py
+++ b/ee_extra/QA/clouds.py
@@ -331,7 +331,7 @@ def maskClouds(
         if isinstance(x, ee.image.Image):
             masked = lookup[platformDict["platform"]](x)
         elif isinstance(x, ee.imagecollection.ImageCollection):
-            if platformDict["platform"] == "COPERNICUS/S2_SR":
+            if platformDict["platform"].startswith("COPERNICUS/S2_SR"):
                 masked = lookup[platformDict["platform"]](x)
             else:
                 masked = x.map(lookup[platformDict["platform"]])


### PR DESCRIPTION
# Fix bug for `S2_SR_HARMONIZED`

## Problem 

ImageCollection `COPERNICUS/S2_SR_HARMONIZED` is not processed correctly, leading to problem in `eemont` when trying to use s2.maskClouds(). 

## Fix
Hard comparison of platform (i.e., `platform == "S3_SR"`) excludes `S2_SR_HARMONIZED`. Simply changed to a more lenient platform comparison (i.e., `.startswith(S3_SR)`). 

Fixes the problem locally on my machine. 