### PR TITLE
fix: drop use of deprecated module pkg_resources

### DIFF
--- a/ee_extra/Apps/utils.py
+++ b/ee_extra/Apps/utils.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Optional, Union
 
 import ee
-import pkg_resources
 
 from ee_extra.utils import _load_JSON
 
@@ -19,9 +18,8 @@ def _get_apps(online: bool) -> dict:
         Apps.
     """
     if online:
-        with urllib.request.urlopen(
-            "https://raw.githubusercontent.com/samapriya/ee-appshot/main/app_urls.json"
-        ) as url:
+        url = "https://raw.githubusercontent.com/samapriya/ee-appshot/main/app_urls.json"
+        with urllib.request.urlopen(url) as url:
             apps = json.loads(url.read().decode())
     else:
         apps = _load_JSON("ee-appshot.json")

--- a/ee_extra/ImageCollection/core.py
+++ b/ee_extra/ImageCollection/core.py
@@ -5,7 +5,6 @@ import warnings
 from typing import Optional, Union
 
 import ee
-import pkg_resources
 
 from ee_extra.STAC.utils import _get_platform_STAC
 

--- a/ee_extra/JavaScript/install.py
+++ b/ee_extra/JavaScript/install.py
@@ -5,7 +5,8 @@ a JavaScript Earth Enginemodule.
 import pathlib
 import re
 import urllib.request
-from pathlib import Path
+
+from importlib.resources import files
 
 
 def _convert_path_to_ee_sources(path: str) -> str:
@@ -31,8 +32,8 @@ def _get_ee_sources_path() -> str:
     Returns:
         The ee-sources folder path.
     """
-    pkgdir = Path(__file__).parents[1]
-    return (pkgdir / "ee-sources").as_posix()
+    pkgdir = files("ee_extra").parent
+    return str(pkgdir / "ee-sources")
 
 
 def _convert_path_to_ee_extra(path: str) -> str:

--- a/ee_extra/JavaScript/install.py
+++ b/ee_extra/JavaScript/install.py
@@ -5,8 +5,7 @@ a JavaScript Earth Enginemodule.
 import pathlib
 import re
 import urllib.request
-
-import pkg_resources
+from pathlib import Path
 
 
 def _convert_path_to_ee_sources(path: str) -> str:
@@ -32,9 +31,8 @@ def _get_ee_sources_path() -> str:
     Returns:
         The ee-sources folder path.
     """
-    ee_extra_py_file = pkg_resources.resource_filename("ee_extra", "ee_extra.py")
-    pkgdir = pathlib.Path(ee_extra_py_file).parent
-    return pkgdir.joinpath("ee-sources").as_posix()
+    pkgdir = Path(__file__).parents[1]
+    return (pkgdir / "ee-sources").as_posix()
 
 
 def _convert_path_to_ee_extra(path: str) -> str:

--- a/ee_extra/STAC/core.py
+++ b/ee_extra/STAC/core.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Optional, Union
 
 import ee
-import pkg_resources
 
 from ee_extra.STAC.utils import _get_platform_STAC
 from ee_extra.utils import _load_JSON

--- a/ee_extra/STAC/utils.py
+++ b/ee_extra/STAC/utils.py
@@ -5,7 +5,6 @@ import warnings
 from typing import Optional, Union
 
 import ee
-import pkg_resources
 
 from ee_extra.utils import _load_JSON
 

--- a/ee_extra/Spectral/utils.py
+++ b/ee_extra/Spectral/utils.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Optional, Union, Tuple, Dict
 
 import ee
-import pkg_resources
 
 from ee_extra.STAC.utils import _get_platform_STAC
 from ee_extra.utils import _load_JSON
@@ -242,9 +241,8 @@ def _get_indices(online: bool) -> dict:
         Indices.
     """
     if online:
-        with urllib.request.urlopen(
-            "https://raw.githubusercontent.com/awesome-spectral-indices/awesome-spectral-indices/main/output/spectral-indices-dict.json"
-        ) as url:
+        url = "https://raw.githubusercontent.com/awesome-spectral-indices/awesome-spectral-indices/main/output/spectral-indices-dict.json"
+        with urllib.request.urlopen(url) as url:
             indices = json.loads(url.read().decode())
     else:
         indices = _load_JSON("spectral-indices-dict.json")
@@ -425,8 +423,8 @@ def _get_tc_coefficients(platform: str) -> dict:
         "TCW": (0.2254, 0.3681, 0.2250, -0.6053, -0.6298)
     }
 
-    # Zhai et al. 2022 coefficients were included for L8 TOA over the Baig 
-    # et al. 2014 coefficients for consistency with the L8 SR coefficients, 
+    # Zhai et al. 2022 coefficients were included for L8 TOA over the Baig
+    # et al. 2014 coefficients for consistency with the L8 SR coefficients,
     # which were not calculated by Baig et al.
     LANDSAT8_TOA = {
         "bands": ("B3", "B4", "B5", "B6", "B7"),

--- a/ee_extra/utils.py
+++ b/ee_extra/utils.py
@@ -1,7 +1,8 @@
 import difflib
 import json
 from typing import Any, Optional, List, Sequence
-from pathlib import Path
+
+from importlib.resources import files
 
 import ee
 
@@ -15,11 +16,9 @@ def _load_JSON(x: Optional[str] = "ee-catalog-ids.json") -> Any:
     Returns:
         JSON file.
     """
-    eeExtraDir = Path(__file__).parent
-    dataPath = eeExtraDir / "data" / x
-    data = json.loads(dataPath.read_text())
-
-    return data
+    data_file = files("ee_extra.data") / file
+    with data_file.open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def _get_case_insensitive_close_matches(

--- a/ee_extra/utils.py
+++ b/ee_extra/utils.py
@@ -1,10 +1,9 @@
 import difflib
 import json
-import os
 from typing import Any, Optional, List, Sequence
+from pathlib import Path
 
 import ee
-import pkg_resources
 
 
 def _load_JSON(x: Optional[str] = "ee-catalog-ids.json") -> Any:
@@ -16,12 +15,9 @@ def _load_JSON(x: Optional[str] = "ee-catalog-ids.json") -> Any:
     Returns:
         JSON file.
     """
-    eeExtraDir = os.path.dirname(
-        pkg_resources.resource_filename("ee_extra", "ee_extra.py")
-    )
-    dataPath = os.path.join(eeExtraDir, "data/" + x)
-    f = open(dataPath)
-    data = json.load(f)
+    eeExtraDir = Path(__file__).parent
+    dataPath = eeExtraDir / "data" / x
+    data = json.loads(dataPath.read_text())
 
     return data
 


### PR DESCRIPTION
related to #57 

as the module `pkg_resources` is deprecated I propose in this PR to replace the few calls that were still active by simple search in the package filetree using `__file__` magic property. 