### PR TITLE
fix: escape all the regex that contained wrong escape characters

### DIFF
--- a/ee_extra/JavaScript/merge.py
+++ b/ee_extra/JavaScript/merge.py
@@ -49,7 +49,7 @@ def junction(x: str) -> str:
     """
     module = _open_module_as_str(x)
 
-    module = re.sub(re.compile("/\*.*?\*/", re.DOTALL), "", module)
+    module = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", module)
     # module = re.sub(re.compile("//.*?\n"), "", module)
 
     lines = module.split("\n")
@@ -68,7 +68,7 @@ def junction(x: str) -> str:
                     .replace('"', "")
                     .replace("'", "")
                 )
-                newText = re.sub(re.compile("/\*.*?\*/", re.DOTALL), "", newText)
+                newText = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", newText)
                 # newText = re.sub(re.compile("//.*?\n"), "", newText)
                 newText = newText.replace("exports", f"eeExtraExports{counter}")
                 newLines.append("var eeExtraExports" + str(counter) + " = AttrDict();")

--- a/ee_extra/JavaScript/translate_functions.py
+++ b/ee_extra/JavaScript/translate_functions.py
@@ -9,9 +9,9 @@ In JavaScript there is three diferent ways of GEE users define functions:
         }                              |    };
     2. GEE users define the function in the middle of the line (yeah it's ok).
         ic.map(function(x) {return x})
-    
+
     3. GEE users define function after export (we hate u!).
-        exports.addBand = function(landsat){ var wrap = function(image){ return 0;} return 0;}        
+        exports.addBand = function(landsat){ var wrap = function(image){ return 0;} return 0;}
 
 This module try to convert all theses cases to Python. If you consider that
 there is more cases that must be added to the module, please, contact us by
@@ -107,7 +107,7 @@ def from_js_to_py_fn_simple(js_function):
         fn_header = js_function
 
     # is there a assignement? e.g. eeExtraExports0.addBand = function(image) {...}
-    tentative_name = regex.findall("(.*\..*)\s=\sfunction\(", fn_header)
+    tentative_name = regex.findall(r"(.*\..*)\s=\sfunction\(", fn_header)
 
     # 2. get function name
     pattern = r"function\s*([\x00-\x7F][^\s]+)\s*\(.*\)\s*{"
@@ -141,7 +141,7 @@ def from_js_to_py_fn_simple(js_function):
     body = regex.search(pattern, fn_header)[0][1:-1].rstrip()
 
     # 6. Init space
-    init_space = regex.match("\s*", fn_header)[0]
+    init_space = regex.match(r"\s*", fn_header)[0]
 
     # 7. py function info
     if tentative_name == []:
@@ -389,7 +389,7 @@ def from_mapjs_to_py_fn_simple(js_function):
     body = regex.search(pattern, fn_header)[0][1:-1].rstrip()
 
     # 6. Init space
-    init_space = regex.match("\s*", fn_header)[0]
+    init_space = regex.match(r"\s*", fn_header)[0]
 
     # 7. py function info
     py_func = f"{init_space}def {function_name}({args_name}):{body}\n"
@@ -599,7 +599,7 @@ def func_translate_case03(x):
         for index in lines_to_work:
             line = lines[index]
             # Does the line inmediately assign a function?
-            if bool(regex.search("=\s*function", line)):
+            if bool(regex.search(r"=\s*function", line)):
                 # Search the name
                 pattern02 = "([^=]*)="
                 export_str = regex.findall(pattern02, line)[0]

--- a/ee_extra/JavaScript/translate_jsm_wrappers.py
+++ b/ee_extra/JavaScript/translate_jsm_wrappers.py
@@ -23,7 +23,7 @@ def get_finditer_cases(condition, text):
     point method.
     """
     regex = _check_regex()
-    
+
     results = list()
     results_position = list()
     for match in regex.finditer(condition, text):
@@ -42,9 +42,9 @@ def fcondition01(line, method_name, attribute=False, extra=""):
     """
     # Detect possible cases (just detect!)
     if not attribute:
-        fcondition = "([\w'\"\]\)%s]+?)\.%s\((?>[^()]+|(?1))*\)" % (extra, method_name)
+        fcondition = r"([\w'\"\]\)%s]+?)\.%s\((?>[^()]+|(?1))*\)" % (extra, method_name)
     else:
-        fcondition = "([\w'\"\]\)%s]+?)\.%s" % (extra, method_name)
+        fcondition = r"([\w'\"\]\)%s]+?)\.%s" % (extra, method_name)
 
     results, results_position = get_finditer_cases(fcondition, line)
 
@@ -93,7 +93,7 @@ def fcondition02(line, method_name="every", extra=""):
         - print([1, 2, 3, 4].every(checkAge)) -> [1, 2, 3, 4].every(checkAge)
         - ["cesar".every(checkAge)] -> "cesar".every(checkAge)
     """
-    fcondition = "([\w'\"\]\)%s]+?)\.%s\((?>[^()]+|(?1))*\)" % (extra, method_name)
+    fcondition = r"([\w'\"\]\)%s]+?)\.%s\((?>[^()]+|(?1))*\)" % (extra, method_name)
     results, results_position = get_finditer_cases(fcondition, line)
     variables = fcondition01(line, method_name=method_name, extra=extra)
 
@@ -116,7 +116,7 @@ def fcondition03(line, method_name, extra=""):
         - print([1, 2, 3, 4].every(checkAge)) -> checkAge
         - ["cesar".every(checkAge)] -> checkAge
     """
-    fcondition = "([\w'\"\]\)%s]+?)\.%s\((?>[^()]+|(?1))*\)" % (extra, method_name)
+    fcondition = r"([\w'\"\]\)%s]+?)\.%s\((?>[^()]+|(?1))*\)" % (extra, method_name)
     results, results_position = get_finditer_cases(fcondition, line)
     variables = fcondition01(line, method_name=method_name, extra=extra)
 
@@ -662,8 +662,8 @@ def translate_trim(x):
     """
     # Regex conditions to get the string to replace,
     # the arguments, and the variable name.
-    var_names = fcondition01(x, "trim", extra="\s")
-    replacement = fcondition02(x, "trim", extra="\s")
+    var_names = fcondition01(x, "trim", extra=r"\s")
+    replacement = fcondition02(x, "trim", extra=r"\s")
 
     # if does not match the condition, return the original string
     if var_names == []:
@@ -1130,7 +1130,7 @@ def translate_some(x):
 
 
 def translate_splice(x):
-    """Converts list.splice(index, howmany, item1, ... itemx) to 
+    """Converts list.splice(index, howmany, item1, ... itemx) to
        __ee_extra_splice(list, index, howmany, item1, ... itemx)
 
     Args:

--- a/ee_extra/JavaScript/translate_loops.py
+++ b/ee_extra/JavaScript/translate_loops.py
@@ -4,7 +4,7 @@ Auxiliary module with functions to translate JavaScript loops to Python.
 In GEE JavaScript there is four diferent ways to define a loop:
 
     1. JS loop FOR.
-    2. JS loop FOR IN.    
+    2. JS loop FOR IN.
     3. JS loop WHILE.
     4. JS loop SWITCH.
 
@@ -46,7 +46,7 @@ def fix_case03_loop(x):
     # Is a line with a for loop?
     for line in lines:
         # 1. Get the text inside parenthesis (ignore nested parenthesis)
-        condition_01 = "(?<=for\s*\()(?:[^()]+|\([^)]+\))+(?=\))"
+        condition_01 = r"(?<=for\s*\()(?:[^()]+|\([^)]+\))+(?=\))"
         matches = list(regex.finditer(condition_01, line))
         if matches == []:
             fulfill_condition.append(False)
@@ -58,7 +58,7 @@ def fix_case03_loop(x):
     index01 = [index for index, x in enumerate(fulfill_condition) if x]
 
     def fast_ck03(line):
-        return regex.findall("\).*", line)[0][1:].strip() == ""
+        return regex.findall(r"\).*", line)[0][1:].strip() == ""
 
     index02 = [index for index, x in enumerate(lines_to_check) if fast_ck03(x)]
     index03 = [index01[x] for x in index02]
@@ -106,9 +106,9 @@ def fix_while_loop(x):
     # line = lines[1]
     for line in lines:
         # 1. Get the text inside parenthesis (ignore nested parenthesis)
-        condition_01 = "(?<=while.*\()(?:[^()]+|\([^)]+\))+(?=\))"
+        condition_01 = r"(?<=while.*\()(?:[^()]+|\([^)]+\))+(?=\))"
         matches = list(regex.finditer(condition_01, line))
-        initial_white_space = regex.findall("^\s*", line)[0]
+        initial_white_space = regex.findall(r"^\s*", line)[0]
         if matches == []:
             list_while_solver.append(line)
             continue
@@ -164,7 +164,7 @@ def fix_for_loop(x):
     # line = lines[1]
     for line in lines:
         # 1. Get the text inside parenthesis (ignore nested parenthesis)
-        condition_01 = "(?<=for\s*\()(?:[^()]+|\([^)]+\))+(?=\))"
+        condition_01 = r"(?<=for\s*\()(?:[^()]+|\([^)]+\))+(?=\))"
         matches = list(regex.finditer(condition_01, line))
         if matches == []:
             list_for_solver.append(line)
@@ -174,7 +174,7 @@ def fix_for_loop(x):
             for_loop_body = match.group()
 
         # initial space
-        initial_white_space = regex.findall("^\s*", line)[0]
+        initial_white_space = regex.findall(r"^\s*", line)[0]
 
         ## Match for in
         if " in " in for_loop_body:
@@ -209,7 +209,7 @@ def fix_for_loop(x):
                 if not for_loop_var in (lgradient + lcond)
             ]
 
-            lcond = regex.sub("\s+", "", lcond[0])
+            lcond = regex.sub(r"\s+", "", lcond[0])
 
             # 5. Get the iterator name and range
             fcop = [cop for cop in cops if cop in lcond][0]
@@ -217,12 +217,12 @@ def fix_for_loop(x):
 
             # this statement is to transform the case of "for(;i < x.length;){...}" to while(i < x.length){...}
             if len(lgradient) == 0:
-                ldef = "\n".join([regex.sub("\s+", "", var_remove(ld)) for ld in ldef])
+                ldef = "\n".join([regex.sub(r"\s+", "", var_remove(ld)) for ld in ldef])
                 ldef = "\n".join(ldef.split(","))
                 python_for_loop = delete_brackets(x="%s\nwhile %s :\n" % (ldef, lcond))
             else:
-                lgradient = regex.sub("\s+", "", lgradient[0])
-                ldef = "\n".join([regex.sub("\s+", "", var_remove(ld)) for ld in ldef])
+                lgradient = regex.sub(r"\s+", "", lgradient[0])
+                ldef = "\n".join([regex.sub(r"\s+", "", var_remove(ld)) for ld in ldef])
                 ldef = "\n".join(ldef.split(","))
 
                 # 6. Get the step value
@@ -369,7 +369,7 @@ def check_loop_line_breaks_r(x):
 
 def check_loop_line_breaks(x):
     regex = _check_regex()
-    
+
     lines = x.split("\n")
     # trace for loop bad line breaks
     condtion = r"^for\s*\("

--- a/ee_extra/JavaScript/translate_main.py
+++ b/ee_extra/JavaScript/translate_main.py
@@ -44,7 +44,7 @@ def fix_typeof(x):
         for typeof_case in typeof_cases:
             x = x.replace(typeof_case, "typeof(%s)" % typeof_case.split(" ")[1])
     header = """
-    
+
     # Javascript typeof wrapper ---------------------------------------
     def typeof(x):
         # Python version of Javascript typeof
@@ -53,7 +53,7 @@ def fix_typeof(x):
         elif x == None:
             return "object"
         elif isinstance(x, bool):
-            return "boolean"  
+            return "boolean"
         elif isinstance(x, (int, float)):
             return "number"
         elif isinstance(x, str):
@@ -86,7 +86,7 @@ def fix_sugar_if(x):
     """
     regex = _check_regex()
     lines = x.split("\n")
-    condition01 = "\(.*\)\s\?\s\w+\s:.*"  # search for sugar strings
+    condition01 = r"\(.*\)\s\?\s\w+\s:.*"  # search for sugar strings
     sugar_lines = [line for line in lines if regex.search(condition01, line)]
 
     if sugar_lines == []:
@@ -95,17 +95,17 @@ def fix_sugar_if(x):
         for sugar_line in sugar_lines:
             if " = " in sugar_line:
                 # initial space
-                whitespace_cond = "^\s*"
+                whitespace_cond = r"^\s*"
                 init_space = regex.findall(whitespace_cond, sugar_line)[0]
 
                 # is there a assignment?
-                condition02 = "(.*)\s+=\s+"
+                condition02 = r"(.*)\s+=\s+"
                 matches = regex.findall(condition02, sugar_line, regex.MULTILINE)
                 varname = matches[0].strip() + " = "
             else:
                 varname = ""
             # sugar syntax is: if (condition) ? true_value : false_value
-            condition03 = "=(.*)\?(.*):(.*)"
+            condition03 = r"=(.*)\?(.*):(.*)"
             ifcondition, dotrue, dofalse = regex.findall(
                 condition03, sugar_line, regex.MULTILINE
             )[0]
@@ -140,7 +140,7 @@ def normalize_fn_name(x: str) -> str:
         >>> # function exp(x){'hi'}
     """
     regex = _check_regex()
-    pattern = "var\s*(.*[^\s])\s*=\s*function"
+    pattern = r"var\s*(.*[^\s])\s*=\s*function"
     matches = regex.finditer(pattern, x, regex.MULTILINE)
     for _, item in enumerate(matches):
         match = item.group(0)
@@ -172,15 +172,15 @@ def change_operators(x):
         {
             "===": " == ",
             "!==": " != ",
-            "\.and\(": ".And(",
-            "\.or\(": ".Or(",
-            "\.not\(": ".Not(",
-            "(?<![a-zA-Z])true(?![a-zA-Z])": "True",
-            "(?<![a-zA-Z])false(?![a-zA-Z])": "False",
-            "(?<![a-zA-Z])null(?![a-zA-Z])": "None",
-            "//": "#",
-            "!(\w)": " not ",
-            "\|\|": " or ",
+            r"\.and\(": ".And(",
+            r"\.or\(": ".Or(",
+            r"\.not\(": ".Not(",
+            r"(?<![a-zA-Z])true(?![a-zA-Z])": "True",
+            r"(?<![a-zA-Z])false(?![a-zA-Z])": "False",
+            r"(?<![a-zA-Z])null(?![a-zA-Z])": "None",
+            r"//": "#",
+            r"!(\w)": " not ",
+            r"\|\|": " or ",
         }
     )
 
@@ -441,7 +441,7 @@ def fix_str_plus_int(x):
         >>> # '"hola" |plus| "mundo" |plus| str(10000)'
     """
     # Header Infix operator class to add if the '+' operator exists.
-    header = """    
+    header = """
     # Javascript sum module -------------------------------------------------------
     class Infix:
         def __init__(self, function):
@@ -456,9 +456,9 @@ def fix_str_plus_int(x):
             return self.function(other)
         def __call__(self, value1, value2):
             return self.function(value1, value2)
-        
+
     def __eextra_plus(*args):
-        try:        
+        try:
             sum_container = 0
             for arg in args:
                 sum_container = sum_container + arg
@@ -550,7 +550,7 @@ def add_identation(x):
 
 
 def remove_extra_spaces(x):
-    """Remove \n and \s if they are at the begining of the string"""
+    r"""Remove \n and \s if they are at the begining of the string"""
     if x[0] == "\n":
         # Remove spaces at the beginning
         word_list = list()
@@ -778,14 +778,14 @@ def add_header(x, header_list=""):
 
 def remove_single_declarations(x):
     regex = _check_regex()
-    condition = "var\s[A-Za-z0-9Α-Ωα-ωίϊΐόάέύϋΰήώ\[\]_]+;*\n"
+    condition = r"var\s[A-Za-z0-9Α-Ωα-ωίϊΐόάέύϋΰήώ\[\]_]+;*\n"
     x = regex.sub(condition, "", x)
     return x
 
 def remove_documentation(x):
     regex = _check_regex()
     # remove // only if it is not in a string
-    condition = "\/\/(?=(?:[^\"']*\"[^\"']*\")*[^\"']*$).*"
+    condition = r"\/\/(?=(?:[^\"']*\"[^\"']*\")*[^\"']*$).*"
     newx = regex.sub(condition, "", x, flags=regex.MULTILINE)
     return newx
 
@@ -850,9 +850,9 @@ def translate(x: str, black: bool = False, quiet: bool = True) -> str:
     x = tloops.fix_inline_iterators(x)
 
     x = if_statement(x)
-    
+
     # 14. Delete extra brackets.
-    x = tgnrl.delete_brackets(x)    
+    x = tgnrl.delete_brackets(x)
 
     # 15. Change [if (condition) ? true_value : false_value] to [true_value if condition else false_value]
     # OBS: fix_sugar_if must always to if_statement to avoid conflicts.
@@ -871,7 +871,7 @@ def translate(x: str, black: bool = False, quiet: bool = True) -> str:
         except ImportError:
             raise ImportError(
                 '"black" is not installed. Please install "black" when using "black=True" -> "pip install black"'
-            )    
+            )
     x, header = fix_str_plus_int(x)
     header_list.append(header)
     x = add_header(x, header_list)

--- a/ee_extra/JavaScript/translate_specialfunctions.py
+++ b/ee_extra/JavaScript/translate_specialfunctions.py
@@ -17,8 +17,8 @@ def functextin(x, fname="parseInt"):
         >>> functextin('parseInt(a=2)')
     """
     regex = _check_regex()
-    
-    search = "(?<![\w\.])%s\(" % fname
+
+    search = r"(?<![\w\.])%s\(" % fname
     matches = regex.finditer(search, x, regex.MULTILINE)
     paranthesis_index = list()
     for _, match in enumerate(matches):


### PR DESCRIPTION
I started to reuse ee_extra from geetools and the javascript parser is triggering plenty of SyntaxtWarnings due to the use of normal strings when dealing with rege. 

I corrected as many as possible. 